### PR TITLE
Enhancement: Easier switching between summary and details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 
 target/
-dbt_modules/
+dbt_packages/
 logs/

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ The query is best used in dbt Develop so you can interactively check results
     primary_key="order_id"
 ) }}
 
-
 ```
 Arguments:
 * `a_relation` and `b_relation`: The [relations](https://docs.getdbt.com/reference#relation)
@@ -69,6 +68,8 @@ Arguments:
   validation.
 * `primary_key` (optional): The primary key of the model. Used to sort unmatched
   results for row-by-row validation.
+* `summary` (optional): Allows you to switch between a summary or detaied view
+  of the compared data. Accepts `true` or `false` vaules. Defaults to `true`.
 
 ## compare_queries ([source](macros/compare_queries.sql))
 Super similar to `compare_relations`, except it takes two select statements. This macro is useful when:
@@ -103,6 +104,10 @@ Super similar to `compare_relations`, except it takes two select statements. Thi
 
 
 ```
+
+Arguments:
+* `summary` (optional): Allows you to switch between a summary or detaied view
+  of the compared data. Accepts `true` or `false` vaules. Defaults to `true`.
 
 ## compare_column_values ([source](macros/compare_column_values.sql))
 This macro will return a query, that, when executed, compares a column across

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Arguments:
   validation.
 * `primary_key` (optional): The primary key of the model. Used to sort unmatched
   results for row-by-row validation.
-* `summary` (optional): Allows you to switch between a summary or detaied view
-  of the compared data. Accepts `true` or `false` vaules. Defaults to `true`.
+* `summary` (optional): Allows you to switch between a summary or detailed view
+  of the compared data. Accepts `true` or `false` values. Defaults to `true`.
 
 ## compare_queries ([source](macros/compare_queries.sql))
 Super similar to `compare_relations`, except it takes two select statements. This macro is useful when:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Arguments:
   validation.
 * `primary_key` (optional): The primary key of the model. Used to sort unmatched
   results for row-by-row validation.
-* `summary` (optional): Allows you to switch between a summary or detailed view
+* `summarize` (optional): Allows you to switch between a summary or detailed view
   of the compared data. Accepts `true` or `false` values. Defaults to `true`.
 
 ## compare_queries ([source](macros/compare_queries.sql))
@@ -106,7 +106,7 @@ Super similar to `compare_relations`, except it takes two select statements. Thi
 ```
 
 Arguments:
-* `summary` (optional): Allows you to switch between a summary or detaied view
+* `summarize` (optional): Allows you to switch between a summary or detaied view
   of the compared data. Accepts `true` or `false` vaules. Defaults to `true`.
 
 ## compare_column_values ([source](macros/compare_column_values.sql))

--- a/integration_tests/models/compare_queries_with_summary.sql
+++ b/integration_tests/models/compare_queries_with_summary.sql
@@ -1,0 +1,13 @@
+{% set a_query %}
+  select * from {{ ref('data_compare_relations__a_relation') }}
+{% endset %}
+
+{% set b_query %}
+  select * from {{ ref('data_compare_relations__b_relation') }}
+{% endset %}
+
+{{ audit_helper.compare_queries(
+    a_query=a_query,
+    b_query=b_query,
+    primary_key="col_a"
+) }}

--- a/integration_tests/models/compare_queries_without_summary.sql
+++ b/integration_tests/models/compare_queries_without_summary.sql
@@ -10,5 +10,5 @@
     a_query=a_query,
     b_query=b_query,
     primary_key="col_a",
-    summary=false
+    summarize=false
 ) }}

--- a/integration_tests/models/compare_queries_without_summary.sql
+++ b/integration_tests/models/compare_queries_without_summary.sql
@@ -1,0 +1,14 @@
+{% set a_query %}
+  select * from {{ ref('data_compare_relations__a_relation') }}
+{% endset %}
+
+{% set b_query %}
+  select * from {{ ref('data_compare_relations__b_relation') }}
+{% endset %}
+
+{{ audit_helper.compare_queries(
+    a_query=a_query,
+    b_query=b_query,
+    primary_key="col_a",
+    summary=false
+) }}

--- a/integration_tests/models/compare_relations_with_summary.sql
+++ b/integration_tests/models/compare_relations_with_summary.sql
@@ -1,0 +1,9 @@
+{% set a_relation=ref('data_compare_relations__a_relation')%}
+
+{% set b_relation=ref('data_compare_relations__b_relation') %}
+
+{{ audit_helper.compare_relations(
+    a_relation=a_relation,
+    b_relation=b_relation,
+    primary_key="col_a"
+) }}

--- a/integration_tests/models/compare_relations_without_summary.sql
+++ b/integration_tests/models/compare_relations_without_summary.sql
@@ -1,0 +1,10 @@
+{% set a_relation=ref('data_compare_relations__a_relation')%}
+
+{% set b_relation=ref('data_compare_relations__b_relation') %}
+
+{{ audit_helper.compare_relations(
+    a_relation=a_relation,
+    b_relation=b_relation,
+    primary_key="col_a",
+    summary=false
+) }}

--- a/integration_tests/models/compare_relations_without_summary.sql
+++ b/integration_tests/models/compare_relations_without_summary.sql
@@ -6,5 +6,5 @@
     a_relation=a_relation,
     b_relation=b_relation,
     primary_key="col_a",
-    summary=false
+    summarize=false
 ) }}

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -5,7 +5,7 @@ models:
     tests:
       - dbt_utils.equality:
           compare_model: ref('expected_results__compare_relations_without_exclude')
-
+          
   - name: compare_queries_with_summary
     tests:
       - dbt_utils.equality:
@@ -16,6 +16,16 @@ models:
       - dbt_utils.equality:
           compare_model: ref('expected_results__compare_without_summary')
           
+  - name: compare_relations_with_summary
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('expected_results__compare_with_summary')
+
+  - name: compare_relations_without_summary
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('expected_results__compare_without_summary')
+
   - name: compare_relations_with_exclude
     tests:
       - dbt_utils.equality:

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -6,6 +6,16 @@ models:
       - dbt_utils.equality:
           compare_model: ref('expected_results__compare_relations_without_exclude')
 
+  - name: compare_queries_with_summary
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('expected_results__compare_with_summary')
+
+  - name: compare_queries_without_summary
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('expected_results__compare_without_summary')
+          
   - name: compare_relations_with_exclude
     tests:
       - dbt_utils.equality:

--- a/integration_tests/seeds/expected_results__compare_with_summary.csv
+++ b/integration_tests/seeds/expected_results__compare_with_summary.csv
@@ -1,0 +1,4 @@
+in_a,in_b,count,percent_of_total
+True,True,1,33.33
+True,False,1,33.33
+False,True,1,33.33

--- a/integration_tests/seeds/expected_results__compare_without_summary.csv
+++ b/integration_tests/seeds/expected_results__compare_without_summary.csv
@@ -1,0 +1,3 @@
+﻿col_a,col_b,in_a,in_b
+2,b,true,false
+2,c,false,true

--- a/macros/compare_queries.sql
+++ b/macros/compare_queries.sql
@@ -1,8 +1,8 @@
-{% macro compare_queries(a_query, b_query, primary_key=None) -%}
-  {{ return(adapter.dispatch('compare_queries', 'audit_helper')(a_query, b_query, primary_key)) }}
+{% macro compare_queries(a_query, b_query, primary_key=None, summary=true) -%}
+  {{ return(adapter.dispatch('compare_queries', 'audit_helper')(a_query, b_query, primary_key, summary)) }}
 {%- endmacro %}
 
-{% macro default__compare_queries(a_query, b_query, primary_key=None) %}
+{% macro default__compare_queries(a_query, b_query, primary_key=None, summary=true) %}
 
 with a as (
 
@@ -66,24 +66,45 @@ all_records as (
 
 ),
 
+{%- if summary %}
+
 summary_stats as (
+
     select
+
         in_a,
         in_b,
         count(*) as count
+
     from all_records
-
     group by 1, 2
+
+),
+
+final as (
+
+    select
+
+        *,
+        round(100.0 * count / sum(count) over (), 2) as percent_of_total
+
+    from summary_stats
+    order by in_a desc, in_b desc
+
 )
--- select * from all_records
--- where not (in_a and in_b)
--- order by {{ primary_key ~ ", " if primary_key is not none }} in_a desc, in_b desc
 
-select
-    *,
-    round(100.0 * count / sum(count) over (), 2) as percent_of_total
+{%- else %}
 
-from summary_stats
-order by in_a desc, in_b desc
+final as (
+    
+    select * from all_records
+    where not (in_a and in_b)
+    order by {{ primary_key ~ ", " if primary_key is not none }} in_a desc, in_b desc
+
+)
+
+{%- endif %}
+
+select * from final
 
 {% endmacro %}

--- a/macros/compare_queries.sql
+++ b/macros/compare_queries.sql
@@ -1,8 +1,8 @@
-{% macro compare_queries(a_query, b_query, primary_key=None, summary=true) -%}
-  {{ return(adapter.dispatch('compare_queries', 'audit_helper')(a_query, b_query, primary_key, summary)) }}
+{% macro compare_queries(a_query, b_query, primary_key=None, summarize=true) -%}
+  {{ return(adapter.dispatch('compare_queries', 'audit_helper')(a_query, b_query, primary_key, summarize)) }}
 {%- endmacro %}
 
-{% macro default__compare_queries(a_query, b_query, primary_key=None, summary=true) %}
+{% macro default__compare_queries(a_query, b_query, primary_key=None, summarize=true) %}
 
 with a as (
 
@@ -66,7 +66,7 @@ all_records as (
 
 ),
 
-{%- if summary %}
+{%- if summarize %}
 
 summary_stats as (
 

--- a/macros/compare_relations.sql
+++ b/macros/compare_relations.sql
@@ -13,7 +13,7 @@
 
 ----
 
-{% macro compare_relations(a_relation, b_relation, exclude_columns=[], primary_key=None) %}
+{% macro compare_relations(a_relation, b_relation, exclude_columns=[], primary_key=None, summary=true) %}
 
 {%- set a_columns = adapter.get_columns_in_relation(a_relation) -%}
 
@@ -35,6 +35,6 @@ select
 from {{ b_relation }}
 {% endset %}
 
-{{ audit_helper.compare_queries(a_query, b_query, primary_key) }}
+{{ audit_helper.compare_queries(a_query, b_query, primary_key, summary) }}
 
 {% endmacro %}

--- a/macros/compare_relations.sql
+++ b/macros/compare_relations.sql
@@ -13,7 +13,7 @@
 
 ----
 
-{% macro compare_relations(a_relation, b_relation, exclude_columns=[], primary_key=None, summary=true) %}
+{% macro compare_relations(a_relation, b_relation, exclude_columns=[], primary_key=None, summarize=true) %}
 
 {%- set a_columns = adapter.get_columns_in_relation(a_relation) -%}
 
@@ -35,6 +35,6 @@ select
 from {{ b_relation }}
 {% endset %}
 
-{{ audit_helper.compare_queries(a_query, b_query, primary_key, summary) }}
+{{ audit_helper.compare_queries(a_query, b_query, primary_key, summarize) }}
 
 {% endmacro %}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Issue #33 Enhancement

- Changed `compare_queries()` macros to take additional argument with param `summary`, which is set to true by default. 
- Changed `compare_queries()` SQL to switch between summary and details SQL dependent on `summary` value
- Changed `compare_relations()` macros to take additional argument with param `summary`, which is set to true by default.
- Ensured `summary` argument is passed in to the call to `compare_queries()` macro within the `compare_relations()` macro.

- Added tests and test data for both `compare_queries` and `compare_relations` macros with and without including the summary argument.
- Added details on the `summary` parameter in the README.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
