### PR TITLE
Remove references to dbt_utils for cross-db functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# audit_helper 0.6.0
+🚨 This version requires dbt Core 1.2 or above, and is ready for dbt utils 1.0.
+
+Changed:
+* add column_name to output of compare_column_values by @leoebfolsom in https://github.com/dbt-labs/dbt-audit-helper/pull/47
+* Easier switching between summary and details by @christineberger in https://github.com/dbt-labs/dbt-audit-helper/pull/52
+* Removes references to dbt_utils for cross-db macros
+
+New features:
+* dbt Cloud instructions for compare_column_values by @SamHarting in https://github.com/dbt-labs/dbt-audit-helper/pull/45
+* Compare all columns macro by @leoebfolsom in https://github.com/dbt-labs/dbt-audit-helper/pull/50
+
+
 # audit_helper 0.5.0
 This version brings full compatibility with dbt-core 1.0. It requires any version (minor and patch) of v1, which means far less need for compatibility releases in the future.
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@ name: 'audit_helper'
 version: '0.4.0'
 config-version: 2
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.2.0", "<2.0.0"]
 
 target-path: "target"
 clean-targets: ["target", "dbt_packages"]

--- a/macros/compare_queries.sql
+++ b/macros/compare_queries.sql
@@ -19,7 +19,7 @@ b as (
 a_intersect_b as (
 
     select * from a
-    {{ dbt_utils.intersect() }}
+    {{ dbt.intersect() }}
     select * from b
 
 ),
@@ -27,7 +27,7 @@ a_intersect_b as (
 a_except_b as (
 
     select * from a
-    {{ dbt_utils.except() }}
+    {{ dbt.except() }}
     select * from b
 
 ),
@@ -35,7 +35,7 @@ a_except_b as (
 b_except_a as (
 
     select * from b
-    {{ dbt_utils.except() }}
+    {{ dbt.except() }}
     select * from a
 
 ),

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<0.9.0"]
+    version: [">=0.9.0", "<2.0.0"]


### PR DESCRIPTION
## Description & motivation
Changes as part of the 0.6.0 release - remove dbt_utils' cross-db stuff.

## Checklist
- [ ] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
