### PR TITLE
bug fix: account for incorrect comparisons involving null values

### DIFF
--- a/integration_tests/seeds/data_compare_all_columns__albertsons_produce.csv
+++ b/integration_tests/seeds/data_compare_all_columns__albertsons_produce.csv
@@ -7,3 +7,4 @@ id,fruit,ripeness
 6,,brown
 7,orange,orange
 9,apple,mushy
+10,apple,

--- a/integration_tests/seeds/expected_results__compare_all_columns_where_clause.csv
+++ b/integration_tests/seeds/expected_results__compare_all_columns_where_clause.csv
@@ -1,10 +1,13 @@
 primary_key,column_name,perfect_match,null_in_a,null_in_b,missing_from_a,missing_from_b,conflicting_values
 8,ID,false,false,false,false,true,false
 9,ID,false,false,false,true,false,false
+10,ID,false,false,false,true,false,false
 6,FRUIT,false,false,true,false,false,false
 8,FRUIT,false,false,false,false,true,false
 9,FRUIT,false,false,false,true,false,false
+10,FRUIT,false,false,false,true,false,false
 2,RIPENESS,false,false,false,false,false,true
 7,RIPENESS,false,true,false,false,false,false
 8,RIPENESS,false,false,false,false,true,false
 9,RIPENESS,false,false,false,true,false,false
+10,RIPENESS,false,false,false,true,false,false

--- a/macros/compare_column_values_verbose.sql
+++ b/macros/compare_column_values_verbose.sql
@@ -20,9 +20,12 @@ b_query as (
             '{{ column_to_compare }}' as column_name,
         {% endif %}
 
-        coalesce(a_query.{{ column_to_compare }} = b_query.{{ column_to_compare }},
-          (a_query.{{ column_to_compare }} is null and b_query.{{ column_to_compare }} is null),
-          false) as perfect_match,
+        coalesce(
+            a_query.{{ column_to_compare }} = b_query.{{ column_to_compare }} and 
+                a_query.{{ primary_key }} is not null and b_query.{{ primary_key }} is not null,
+            (a_query.{{ column_to_compare }} is null and b_query.{{ column_to_compare }} is null),
+            false
+        ) as perfect_match,
         a_query.{{ column_to_compare }} is null and a_query.{{ primary_key }} is not null as null_in_a,
         b_query.{{ column_to_compare }} is null and b_query.{{ primary_key }} is not null as null_in_b,
         a_query.{{ primary_key }} is null as missing_from_a,

--- a/macros/compare_column_values_verbose.sql
+++ b/macros/compare_column_values_verbose.sql
@@ -30,10 +30,13 @@ b_query as (
         b_query.{{ column_to_compare }} is null and b_query.{{ primary_key }} is not null as null_in_b,
         a_query.{{ primary_key }} is null as missing_from_a,
         b_query.{{ primary_key }} is null as missing_from_b,
-        coalesce(a_query.{{ column_to_compare }} != b_query.{{ column_to_compare }} and
-            (a_query.{{ column_to_compare }} is not null or b_query.{{ column_to_compare }} is not null), false)
-          as conflicting_values
-           -- considered a conflict if the values do not match AND at least one of the values is not null.
+        coalesce(
+            a_query.{{ column_to_compare }} != b_query.{{ column_to_compare }}  or 
+                (a_query.{{ column_to_compare }} is not null and b_query.{{ column_to_compare }} is null) or 
+                (a_query.{{ column_to_compare }} is null and b_query.{{ column_to_compare }} is not null), 
+            false
+        ) as conflicting_values
+        -- considered a conflict if the values do not match AND at least one of the values is not null.
 
     from a_query
 

--- a/macros/compare_column_values_verbose.sql
+++ b/macros/compare_column_values_verbose.sql
@@ -31,9 +31,13 @@ b_query as (
         a_query.{{ primary_key }} is null as missing_from_a,
         b_query.{{ primary_key }} is null as missing_from_b,
         coalesce(
-            a_query.{{ column_to_compare }} != b_query.{{ column_to_compare }}  or 
-                (a_query.{{ column_to_compare }} is not null and b_query.{{ column_to_compare }} is null) or 
-                (a_query.{{ column_to_compare }} is null and b_query.{{ column_to_compare }} is not null), 
+            a_query.{{ primary_key }} is not null and b_query.{{ primary_key }} is not null and 
+            -- ensure that neither value is missing before considering it a conflict
+            (
+                a_query.{{ column_to_compare }} != b_query.{{ column_to_compare }} or -- two not-null values that do not match
+                (a_query.{{ column_to_compare }} is not null and b_query.{{ column_to_compare }} is null) or -- null in b and not null in a
+                (a_query.{{ column_to_compare }} is null and b_query.{{ column_to_compare }} is not null) -- null in a and not null in b
+            ), 
             false
         ) as conflicting_values
         -- considered a conflict if the values do not match AND at least one of the values is not null.


### PR DESCRIPTION
## Description & motivation

Currently, the `compare_all_columns` macro does a poor job of distinguishing between missing data and null values.

We must check to see if the primary key exists in both of the two tables to determine whether the value in that table is null or missing.

With this update, the code checks that a primary key exists in both tables before declaring a `perfect_match`. This was already accounted for in other logical checks (e.g., `null_in_a`, `null_in_b`).

There are also errors in the `conflicting_values` logic leading to incorrectly counting `conflicting_values` as false when comparing a `null` to a `not null` value when the PKs are present in both tables.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
