### PR TITLE
fix test expected results for compare_all_columns

### DIFF
--- a/integration_tests/seeds/expected_results__compare_all_columns_with_summary.csv
+++ b/integration_tests/seeds/expected_results__compare_all_columns_with_summary.csv
@@ -1,4 +1,4 @@
 column_name,perfect_match,null_in_a,null_in_b,missing_from_a,missing_from_b,conflicting_values
-ID,7,0,0,1,1,0
-FRUIT,6,0,1,1,1,0
-RIPENESS,5,1,0,1,1,1
+ID,7,0,0,1,2,0
+FRUIT,6,0,1,1,2,1
+RIPENESS,5,1,1,1,2,1

--- a/integration_tests/seeds/expected_results__compare_all_columns_with_summary_and_exclude.csv
+++ b/integration_tests/seeds/expected_results__compare_all_columns_with_summary_and_exclude.csv
@@ -1,3 +1,3 @@
 column_name,perfect_match,null_in_a,null_in_b,missing_from_a,missing_from_b,conflicting_values
-ID,7,0,0,1,1,0
-FRUIT,6,0,1,1,1,0
+ID,7,0,0,1,2,0
+FRUIT,6,0,1,1,2,1

--- a/integration_tests/seeds/expected_results__compare_all_columns_without_summary.csv
+++ b/integration_tests/seeds/expected_results__compare_all_columns_without_summary.csv
@@ -8,6 +8,7 @@ primary_key,column_name,perfect_match,null_in_a,null_in_b,missing_from_a,missing
 7,ID,true,false,false,false,false,false
 8,ID,false,false,false,false,true,false
 9,ID,false,false,false,true,false,false
+10,ID,false,false,false,true,false,false
 1,FRUIT,true,false,false,false,false,false
 2,FRUIT,true,false,false,false,false,false
 3,FRUIT,true,false,false,false,false,false
@@ -17,6 +18,7 @@ primary_key,column_name,perfect_match,null_in_a,null_in_b,missing_from_a,missing
 7,FRUIT,true,false,false,false,false,false
 8,FRUIT,false,false,false,false,true,false
 9,FRUIT,false,false,false,true,false,false
+10,FRUIT,false,false,false,true,false,false
 1,RIPENESS,true,false,false,false,false,false
 2,RIPENESS,false,false,false,false,false,true
 3,RIPENESS,true,false,false,false,false,false
@@ -26,3 +28,4 @@ primary_key,column_name,perfect_match,null_in_a,null_in_b,missing_from_a,missing
 7,RIPENESS,false,true,false,false,false,false
 8,RIPENESS,false,false,false,false,true,false
 9,RIPENESS,false,false,false,true,false,false
+10,RIPENESS,false,false,true,true,false,false


### PR DESCRIPTION
## Description & motivation
In my haste, I failed to consider that changing the Albertson's seed data would impact _all_ the `compare_all_columns` tests.

By the way, is the test suite actually running in CI/CD? It doesn't really seem like it, else this would have been caught.

I didn't figure out a way to actually run the tests locally, so I'm not 1000% sure the expected results are correct.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
