### PR TITLE
remove internal macro and todo from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,11 +355,3 @@ flag.
 ```
 dbt test --select stg_customers --store-failures
 ```
-
-## compare_column_values_verbose ([source](macros/compare_column_values_verbose.sql))
-This macro will return a query that, when executed, returns the same information as 
-`compare_column_values`, but not summarized. `compare_column_values_verbose` enables `compare_all_columns` to give the user more flexibility around what will result in a test failure.
-
-
-# To-do:
-* Macro to check if two schemas contain the same relations


### PR DESCRIPTION
## Description & motivation
This PR addresses two separate issues:
- https://github.com/dbt-labs/dbt-audit-helper/issues/64
- The `compare_column_values_verbose` part of https://github.com/dbt-labs/dbt-audit-helper/issues/61

Note that I explained the context of `compare_column_values_verbose` in [this comment](https://github.com/dbt-labs/dbt-audit-helper/issues/61#issuecomment-1485906314). 

tl;dr is that I'm hoping we can keep it as an internal macro to make the code easier to understand; but regardless, it should be removed from the readme to reduce readme overwhelm. `compare_column_values_verbose` is an internal macro used by another macro in the package itself, and doesn't really need to be exposed to the user (and certainly not in the readme).

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable) (definitely applicable!)
- [x] I have added tests & descriptions to my models (and macros if applicable)
