### PR TITLE
Add row filtering for relations in compare_all_columns macro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Note: For adapters other than BigQuery, Postgres, Redshift, and Snowflake, the o
 
 ## compare_all_columns ([source](macros/compare_all_columns.sql))
 This macro is designed to be added to a dbt test suite as a custom test. A 
-`compare_all_columns` test monitors changes data values when code is changed 
+`compare_all_columns` test monitors changes to data values when code is changed 
 as part of a PR or during development. It sets up a test that will fail 
 if any column values do not match. 
 
@@ -303,6 +303,7 @@ where conflicting_values
   validation.
 * `primary_key`: The primary key of the model. Used to sort unmatched
   results for row-by-row validation.
+* `a_where` and `b_where` (optional): A SQL where clause used to filter the rows that will be returned from the relations for comparison. Example: `where updated_at > '1900-01-01 23:59:59'` 
 
 If you want to create test results that include columns from the model itself 
 for easier inspection, that can be written into the test:

--- a/integration_tests/models/compare_all_columns_with_relation_where_clauses.sql
+++ b/integration_tests/models/compare_all_columns_with_relation_where_clauses.sql
@@ -1,0 +1,11 @@
+{% set a_relation=ref('data_compare_all_columns__market_of_choice_produce')%}
+
+{% set b_relation=ref('data_compare_all_columns__albertsons_produce') %}
+
+{{ audit_helper.compare_all_columns(
+    a_relation=a_relation,
+    b_relation=b_relation,
+    primary_key="id",
+    a_where='where 1=1',
+    b_where='where 1=1'
+) }}

--- a/macros/compare_all_columns.sql
+++ b/macros/compare_all_columns.sql
@@ -1,8 +1,8 @@
-{% macro compare_all_columns( a_relation, b_relation, primary_key,  exclude_columns=[],summarize=true ) -%}
-  {{ return(adapter.dispatch('compare_all_columns', 'audit_helper')( a_relation, b_relation, primary_key, exclude_columns, summarize )) }}
+{% macro compare_all_columns( a_relation, b_relation, primary_key, a_where, b_where, exclude_columns=[], summarize=true ) -%}
+  {{ return(adapter.dispatch('compare_all_columns', 'audit_helper')( a_relation, b_relation, primary_key, a_where, b_where, exclude_columns, summarize )) }}
 {%- endmacro %}
 
-{% macro default__compare_all_columns( a_relation, b_relation, primary_key, exclude_columns=[], summarize=true ) -%}
+{% macro default__compare_all_columns( a_relation, b_relation, primary_key, a_where, b_where, exclude_columns=[], summarize=true ) -%}
 
   {% set column_names = dbt_utils.get_filtered_columns_in_relation(from=a_relation, except=exclude_columns) %}
 
@@ -10,12 +10,14 @@
     select
       *
     from {{ a_relation }}
+    {% if a_where %}{{ a_where }}{% endif %}
   {% endset %}
 
   {% set b_query %}
     select
       *
     from {{ b_relation }}
+    {% if b_where %}{{ b_where }}{% endif %}
   {% endset %}
 
   {% for column_name in column_names %}


### PR DESCRIPTION
## Description & motivation
Enhancement to compare_all_values macro to allow for filtering of the row population returned from the relation. 

## Checklist
- [X] I have verified that these changes work locally
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
