### PR TITLE
Fix group by in compare_column_values

### DIFF
--- a/macros/compare_column_values.sql
+++ b/macros/compare_column_values.sql
@@ -50,7 +50,7 @@ aggregated as (
         count(*) as count_records
     from joined
 
-    group by column_name, match_status, match_order
+    group by '{{ column_to_compare }}', match_status, match_order
 )
 
 select

--- a/macros/compare_column_values.sql
+++ b/macros/compare_column_values.sql
@@ -50,7 +50,7 @@ aggregated as (
         count(*) as count_records
     from joined
 
-    group by '{{ column_to_compare }}', match_status, match_order
+    group by match_status, match_order
 )
 
 select


### PR DESCRIPTION
## Description & motivation
Grouping by aliases does not seem to be permitted in SQL standard
Fix https://github.com/dbt-labs/dbt-audit-helper/issues/87

## Checklist
- [x] I have verified that these changes work locally
- ~~I have updated the README.md (if applicable)~~
- ~~I have added tests & descriptions to my models (and macros if applicable)~~
