### PR TITLE
Fix audit_query CTE in compare_all_columns

### DIFF
--- a/macros/compare_all_columns.sql
+++ b/macros/compare_all_columns.sql
@@ -48,7 +48,7 @@
 
     /*  There will be one audit_query subquery for each column
     */
-    select * from ( {{ audit_query }} )
+    select * from ( {{ audit_query }} ) AS x
 
     {% if not loop.last %}
 

--- a/macros/compare_all_columns.sql
+++ b/macros/compare_all_columns.sql
@@ -48,7 +48,7 @@
 
     /*  There will be one audit_query subquery for each column
     */
-    ( {{ audit_query }} )
+    select * from ( {{ audit_query }} )
 
     {% if not loop.last %}
 


### PR DESCRIPTION
## Description & motivation
Add select * before audit_query CTE in compare_all_columns macro, in order to fix query error in Presto.
Fix https://github.com/dbt-labs/dbt-audit-helper/issues/89

## Checklist
- [x] I have verified that these changes work locally
- ~~I have updated the README.md (if applicable)~~
- ~~I have added tests & descriptions to my models (and macros if applicable)~~
