### PR TITLE
Add detect column differences

### DIFF
--- a/integration_tests/models/detect_column_changes.sql
+++ b/integration_tests/models/detect_column_changes.sql
@@ -1,0 +1,9 @@
+{% set a_relation=ref('data_detect_column_changes_a')%}
+
+{% set b_relation=ref('data_detect_column_changes_b') %}
+
+{{ audit_helper.detect_column_changes(
+    a_relation=a_relation,
+    b_relation=b_relation,
+    primary_key="id"
+) }}

--- a/integration_tests/models/detect_column_changes_exclude_col.sql
+++ b/integration_tests/models/detect_column_changes_exclude_col.sql
@@ -1,0 +1,10 @@
+{% set a_relation=ref('data_detect_column_changes_a')%}
+
+{% set b_relation=ref('data_detect_column_changes_b') %}
+
+{{ audit_helper.detect_column_changes(
+    a_relation=a_relation,
+    b_relation=b_relation,
+    primary_key="id",
+    exclude_columns=["becomes_null"]
+) }}

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -80,3 +80,13 @@ models:
     tests:
       - dbt_utils.equality:
           compare_model: ref('expected_results__compare_without_summary')
+
+  - name: detect_column_changes
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('expected_results__detect_column_changes')
+
+  - name: detect_column_changes_exclude_cols
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('expected_results__detect_column_changes_exclude_cols')

--- a/integration_tests/package-lock.yml
+++ b/integration_tests/package-lock.yml
@@ -1,0 +1,5 @@
+packages:
+- local: ../
+- package: dbt-labs/dbt_utils
+  version: 1.1.1
+sha1_hash: de2deba3d66ce03d8c02949013650cc9b94f6030

--- a/integration_tests/seeds/data_detect_column_changes_a.csv
+++ b/integration_tests/seeds/data_detect_column_changes_a.csv
@@ -1,0 +1,5 @@
+id,value_changes,becomes_null,becomes_not_null,does_not_change
+1,pink,22,a,dave
+2,blue,33,,dave
+3,green,44,c,dave
+4,yellow,55,d,dave

--- a/integration_tests/seeds/data_detect_column_changes_b.csv
+++ b/integration_tests/seeds/data_detect_column_changes_b.csv
@@ -1,0 +1,5 @@
+id,value_changes,becomes_null,becomes_not_null,does_not_change
+1,red,22,a,dave
+2,blue,,b,dave
+3,green,44,c,dave
+4,yellow,55,d,dave

--- a/integration_tests/seeds/expected_results__detect_column_changes.csv
+++ b/integration_tests/seeds/expected_results__detect_column_changes.csv
@@ -1,0 +1,6 @@
+column_name,is_changed
+id,false
+value_changes,true
+becomes_null,true
+becomes_not_null,true
+does_not_change,false

--- a/integration_tests/seeds/expected_results__detect_column_changes_exclude_col.csv
+++ b/integration_tests/seeds/expected_results__detect_column_changes_exclude_col.csv
@@ -1,0 +1,5 @@
+column_name,is_changed
+id,false
+value_changes,true
+becomes_not_null,true
+does_not_change,false

--- a/macros/detect_column_changes.sql
+++ b/macros/detect_column_changes.sql
@@ -1,0 +1,41 @@
+{% macro detect_column_changes(a_relation, b_relation, primary_key, exclude_columns=[]) %}
+
+{% set column_names = dbt_utils.get_filtered_columns_in_relation(from=a_relation, except=exclude_columns) %}
+
+with bool_or as (
+
+    select 
+        true as anchor
+        {% for column in column_names %}
+            {% set compare_statement %}
+                (a.{{ column | lower }} != b.{{ column | lower }}
+                or a.{{ column | lower }} is null and b.{{ column | lower }} is not null
+                or a.{{ column | lower }} is not null and b.{{ column | lower }} is null)
+            {% endset %}
+        
+        , {{ dbt.bool_or(compare_statement) }} as {{ column | lower }}_is_changed
+    
+        {% endfor %}
+    from {{ a_relation }} as a
+    inner join {{ b_relation }} as b
+        on a.{{ primary_key }} = b.{{ primary_key }}
+
+)
+
+{% for column in column_names %}
+
+    select 
+        '{{ column | lower }}' as column_name, 
+        {{ column | lower }}_is_changed as is_changed 
+    
+    from bool_or
+
+    {% if not loop.last %}
+        
+    union all 
+
+    {% endif %}
+
+{% endfor %}
+
+{% endmacro %}


### PR DESCRIPTION
## Description & motivation

This PR adds a new `detect_column_changes` to help quickly identify which columns have _any_ value-level changes to help narrow down which columns need attention when tracking down differences between two relations. 

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
