### PR TITLE
Correct `quick_are_queries_identical` code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ This can be calculated relatively quickly compared to other macros in this packa
     select * from {{ ref('dim_product') }}
 {% endset %}
 
-{{ audit_helper.compare_column_values(
+{{ audit_helper.quick_are_queries_identical(
     a_query = old_query,
     b_query = new_query,
     columns=['order_id', 'amount', 'customer_id']

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ This can be calculated relatively quickly compared to other macros in this packa
 {% endset %}
 
 {{ audit_helper.quick_are_queries_identical(
-    a_query = old_query,
-    b_query = new_query,
+    query_a = old_query,
+    query_b = new_query,
     columns=['order_id', 'amount', 'customer_id']
   ) 
 }}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
The current README example for `quick_are_queries_identical` uses the `compare_column_values` macro. When following the code example, a user gets the error `Compilation Error in model audit (models/audit.sql)
  macro 'dbt_macro__compare_column_values' takes no keyword argument 'columns'`. This PR corrects the code example to use the correct macro :) 
## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
