### PR TITLE
Update CI trigger to run off forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
     push:
         branches:
             - main
-    pull_request:
+    pull_request_target:
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Problem

PRs from forks will fail CI because the PR trigger is `pull_request` so they do not have access to teh repo vars that are needed since the workflow runs in the context of the fork.  

### Solution

Update to trigger off `pull_request_target` and the workflow runs in the context of the base branch (this repo).

Will not require a release as this only affects local repo CI.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
